### PR TITLE
Equivalent snippets should actually be equivalent

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,13 +361,13 @@ foo = x y * z * y
 If you can't resist using `($)`, never mix it with `(.)` like this:
 
 ``` haskell
-foo = foo . bar . mu $ zot bob
+foo = foo . bar . mu $ zot
 ```
 
 Use parens:
 
 ``` haskell
-foo = (foo . bar . mu) zot bob
+foo = (foo . bar . mu) zot
 ```
 
 (Tee hee!)


### PR DESCRIPTION
`foo = foo . bar . mu $ zot bob` means `foo = (foo . bar . mu) (zot bob)`, not the suggested refactoring, but the latter looks like a broken version of `(foo . bar . mu . zot) bob`, so change the example altogether.

To double-check, I confirmed with `ghci` that `(+) $ 1 2` is indeed an error.
